### PR TITLE
Add option to ignore appIDs

### DIFF
--- a/background/extensionservice.js
+++ b/background/extensionservice.js
@@ -3,7 +3,7 @@ if (typeof browser == "undefined") {
   globalThis.browser = chrome;
 
   console.log('Steamworks extras: Importing scripts');
-  
+
   importScripts('../data/defaultsettings.js');
   importScripts('../scripts/helpers.js');
   importScripts('offscreen/offscreenmanager.js');
@@ -295,7 +295,7 @@ const parseAppIDs = async () => {
 
 const getAppIDs = async () => {
   console.log('Steamworks extras: Getting AppIDs');
-  
+
   let result = await getBrowser().storage.local.get("appIDs");
 
   console.log('Steamworks extras: AppIDs: ', result);
@@ -309,6 +309,14 @@ const getAppIDs = async () => {
   }
   else {
     appIDs = result.appIDs;
+  }
+
+  const ignoredResult = await getBrowser().storage.local.get("ignoredAppIDs");
+  const ignoredAppIDs = ignoredResult.ignoredAppIDs || [];
+
+  if (ignoredAppIDs.length > 0) {
+    appIDs = appIDs.filter(appID => !ignoredAppIDs.includes(appID));
+    console.log('Steamworks extras: Filtered AppIDs (removed ignored): ', appIDs);
   }
 
   return appIDs;
@@ -365,14 +373,17 @@ const initIDs = async () => {
     return false;
   }
 
+  // Get filtered appIDs (excluding ignored ones) for package ID initialization
+  const filteredAppIDs = await getAppIDs();
+
   let packageIDs = {};
-  for (const appID of appIDs) {
+  for (const appID of filteredAppIDs) {
     const IDs = await getPackageIDs(appID);
 
     packageIDs[appID] = IDs;
   }
 
-  console.log('Steamworks extras: AppIDs and PackageIDs have been initialized.', appIDs, packageIDs);
+  console.log('Steamworks extras: AppIDs and PackageIDs have been initialized.', filteredAppIDs, packageIDs);
   return true;
 }
 

--- a/data/defaultsettings.js
+++ b/data/defaultsettings.js
@@ -8,5 +8,6 @@ const defaultSettings = {
   "showZeroRevenues": false,
   "showPercentages": false,
   "chartMaxBreakdown": 10,
-  "statsUpdateInterval": 60
+  "statsUpdateInterval": 60,
+  "ignoredAppIDs": []
 }

--- a/options/options.html
+++ b/options/options.html
@@ -115,6 +115,13 @@
                             background. Updates are also triggered when you open your getBrowser().</td>
                     </tr>
                     <tr>
+                        <td class="table_label"><label for="ignored_app_ids">Ignored AppIDs:</label>
+                        </td>
+                        <td class="table_value"><textarea id="ignored_app_ids" rows="3" cols="30" placeholder="Enter AppIDs separated by commas (e.g., 123456, 789012)"></textarea>
+                        </td>
+                        <td class="description">AppIDs to ignore when fetching data and displaying in reports. Separate multiple AppIDs with commas.</td>
+                    </tr>
+                    <tr>
                         <td class="table_value"><button id="save">Save</button></td>
                         <td class="description"></td>
                     </tr>

--- a/styles/options.css
+++ b/styles/options.css
@@ -109,7 +109,7 @@ th {
 }
 
 .table_value {
-  width: 80px;
+  width: 120px;
 }
 
 .table_value input {
@@ -118,6 +118,19 @@ th {
   border: 0px;
   height: 20px;
   margin: 0 5px 0 5px;
+}
+
+.table_value textarea {
+  background-color: #333;
+  color: #ffffff;
+  border: 0px;
+  margin: 0 5px 0 5px;
+  resize: vertical;
+  font-family: inherit;
+  font-size: 12px;
+  width: 100%;
+  max-width: 100px;
+  box-sizing: border-box;
 }
 
 #cache table {


### PR DESCRIPTION
I needed this option for what is probably a very rare edge-case. We have an app on our Steamworks account that has been migrated away, but it still shows up in our list of apps. 

From what it looks like, when you migrate away an app on Steamworks you can still view any data that was generated before the migration, but anything after that is unavailable. This causes an error in the extension, and prevents you from seeing any data from any of your other functioning apps. 

Here's how the setting looks like in the settings screen: 
<img width="1129" height="197" alt="image" src="https://github.com/user-attachments/assets/950147c4-8b49-4aaa-8a16-a8d9257f8c08" />

Feel free to reject this PR if it feels too narrow in usefulness, I will personally need this feature though so it would be convenient for me to not have to maintain a fork of this extension :)
